### PR TITLE
Add on-push int-* github action

### DIFF
--- a/.github/workflows/coin-integration.yml
+++ b/.github/workflows/coin-integration.yml
@@ -39,4 +39,5 @@ jobs:
         run: |
             export COIN=$(echo ${GITHUB_REF#refs/heads/int-})
             echo "I hope you remembered to run 'yarn version --prerelease --preid \"$COIN\"'"
+            [ -z "$COIN" ] && echo "the COIN tag is not set. Aborting publish" && exit 1
             yarn publish --tag "$COIN"

--- a/.github/workflows/coin-integration.yml
+++ b/.github/workflows/coin-integration.yml
@@ -1,0 +1,42 @@
+name: coin-integration-alpha
+on:
+  push:
+    branches:
+      - 'int-*'
+jobs:
+  prebuild-for-platform:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, macos-latest, windows-2016]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+          registry-url: https://registry.npmjs.org
+          always-auth: true
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '2.7.x'
+      - name: install
+        run: yarn --frozen-lockfile --ignore-scripts
+      - name: fetch libcore
+        run: yarn preinstall
+      - name: config gcc
+        if: runner.os == 'Linux'
+        run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+      - name: prebuild for electron 9.0
+        run: npx node-pre-gyp configure build package --runtime=electron --target=9.0.0 --build-from-source --dist-url=https://electronjs.org/headers
+      - name: prebuild for electron 8.2
+        run: npx node-pre-gyp configure build package --runtime=electron --target=8.2.0 --build-from-source --dist-url=https://electronjs.org/headers
+      - name: prebuild for node 12
+        run: npx node-pre-gyp configure build package --target=12.16.0
+      - name: Get version and publish @coin on NPM
+        if: matrix.os == 'ubuntu-16.04'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_GAGBO_PUBLISH_TOKEN }}
+        run: |
+            export COIN=$(echo ${GITHUB_REF#refs/heads/int-})
+            echo "I hope you remembered to run 'yarn version --prerelease --preid \"$COIN\"'"
+            yarn publish --tag "$COIN"

--- a/include/BitcoinLikeOutput.hpp
+++ b/include/BitcoinLikeOutput.hpp
@@ -63,6 +63,14 @@ public:
     virtual std::shared_ptr<DerivationPath> getDerivationPath() = 0;
 
     virtual std::experimental::optional<int64_t> getBlockHeight() = 0;
+
+    /**
+     * Check if the transaction (which created this output) is replaceable (RBF).
+     * An output can be replaceable if the transaction has at least one RBF input
+     * and if the transaction is not a block.
+     * @return true if the output is replaceable, false otherwise
+     */
+    virtual bool isReplaceable() const = 0;
 };
 
 } } }  // namespace ledger::core::api

--- a/include/CosmosConfigurationDefaults.cpp
+++ b/include/CosmosConfigurationDefaults.cpp
@@ -5,7 +5,7 @@
 
 namespace ledger { namespace core { namespace api {
 
-std::string const CosmosConfigurationDefaults::COSMOS_DEFAULT_API_ENDPOINT = {"http://lite-client-0e27eefb-4031-4859-a88e-249fd241989d.cosmos.bison.run:1317"};
+std::string const CosmosConfigurationDefaults::COSMOS_DEFAULT_API_ENDPOINT = {"https://cosmos.coin.staging.aws.ledger.com"};
 
 std::string const CosmosConfigurationDefaults::COSMOS_OBSERVER_WS_ENDPOINT = {""};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/ledger-core",
-  "version": "6.5.4",
+  "version": "6.6.0",
   "libcoreVersion": "3.4.1-rc-ac6350",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ledgerhq/ledger-core",
   "version": "6.5.4",
-  "libcoreVersion": "3.4.1-rc-5efb46",
+  "libcoreVersion": "3.4.1-rc-ac6350",
   "description": "Ledger Core Library cross-platform C++ bindings for NodeJs",
   "main": "js/index.js",
   "repository": {

--- a/src/NJSBitcoinLikeOutputCpp.cpp
+++ b/src/NJSBitcoinLikeOutputCpp.cpp
@@ -228,6 +228,31 @@ NAN_METHOD(NJSBitcoinLikeOutput::getBlockHeight) {
     //Return result
     info.GetReturnValue().Set(arg_0);
 }
+NAN_METHOD(NJSBitcoinLikeOutput::isReplaceable) {
+
+    //Check if method called with right number of arguments
+    if(info.Length() != 0)
+    {
+        return Nan::ThrowError("NJSBitcoinLikeOutput::isReplaceable needs 0 arguments");
+    }
+
+    //Check if parameters have correct types
+
+    //Unwrap current object and retrieve its Cpp Implementation
+    auto cpp_impl = djinni::js::ObjectWrapper<ledger::core::api::BitcoinLikeOutput>::Unwrap(info.This());
+    if(!cpp_impl)
+    {
+        return Nan::ThrowError("NJSBitcoinLikeOutput::isReplaceable : implementation of BitcoinLikeOutput is not valid");
+    }
+
+    auto result = cpp_impl->isReplaceable();
+
+    //Wrap result in node object
+    auto arg_0 = Nan::New<Boolean>(result);
+
+    //Return result
+    info.GetReturnValue().Set(arg_0);
+}
 
 NAN_METHOD(NJSBitcoinLikeOutput::New) {
     //Only new allowed
@@ -282,6 +307,7 @@ void NJSBitcoinLikeOutput::Initialize(Local<Object> target) {
     Nan::SetPrototypeMethod(func_template,"getAddress", getAddress);
     Nan::SetPrototypeMethod(func_template,"getDerivationPath", getDerivationPath);
     Nan::SetPrototypeMethod(func_template,"getBlockHeight", getBlockHeight);
+    Nan::SetPrototypeMethod(func_template,"isReplaceable", isReplaceable);
     Nan::SetPrototypeMethod(func_template,"isNull", isNull);
     //Set object prototype
     BitcoinLikeOutput_prototype.Reset(objectTemplate);

--- a/src/NJSBitcoinLikeOutputCpp.hpp
+++ b/src/NJSBitcoinLikeOutputCpp.hpp
@@ -69,6 +69,14 @@ private:
 
     static NAN_METHOD(getBlockHeight);
 
+    /**
+     * Check if the transaction (which created this output) is replaceable (RBF).
+     * An output can be replaceable if the transaction has at least one RBF input
+     * and if the transaction is not a block.
+     * @return true if the output is replaceable, false otherwise
+     */
+    static NAN_METHOD(isReplaceable);
+
     static NAN_METHOD(New);
 
     static NAN_METHOD(isNull);

--- a/src/ledgercore_doc.js
+++ b/src/ledgercore_doc.js
@@ -3261,6 +3261,13 @@ declare class NJSBitcoinLikeOutput
     declare function getAddress(): ?string;
     declare function getDerivationPath(): ?NJSDerivationPath;
     declare function getBlockHeight(): ?number;
+    /**
+     * Check if the transaction (which created this output) is replaceable (RBF).
+     * An output can be replaceable if the transaction has at least one RBF input
+     * and if the transaction is not a block.
+     * @return true if the output is replaceable, false otherwise
+     */
+    declare function isReplaceable(): boolean;
 }
 /** Class representing Bitcoin block */
 declare class NJSBitcoinLikeBlock


### PR DESCRIPTION
For coin integration branches, it is necessary to trigger this push to
help testers down the road (Live-common CLI tests).

Any push/merge on int-COIN will push a new @ledgerhq/ledger-core@COIN so
that live-common-only users don't need a full GCC toolchain to test the
current version in CLI.